### PR TITLE
Remove duplicate CVEs in output (fixes #25)

### DIFF
--- a/src/vulnix/main.py
+++ b/src/vulnix/main.py
@@ -21,6 +21,7 @@ See vulnix --help for a full list of options.
 from .nix import Store
 from .nvd import NVD, DEFAULT_MIRROR, DEFAULT_CACHE_DIR
 from .whitelist import WhiteList
+from .utils import cve_url
 import click
 import glob
 import logging
@@ -102,8 +103,8 @@ def output(affected_derivations, verbosity, notfixed):
                 for root in derivation.roots():
                     click.echo("\t" + root)
         click.echo("CVEs:")
-        for cve in derivation.affected_by:
-            click.echo("\t" + cve.url)
+        for cve_id in derivation.affected_by:
+            click.echo("\t" + cve_url(cve_id))
         status.append(1 if derivation.status == 'inprogress' else 2)
 
     return max(status)

--- a/src/vulnix/nix.py
+++ b/src/vulnix/nix.py
@@ -107,7 +107,8 @@ class Derive(object):
                         continue
                     if (vuln, affected_product, self) in whitelist:
                         continue
-                    self.affected_by.add(vuln)
+
+                    self.affected_by.add(vuln.cve_id)
                     break
 
     def matches(self, cve_id, cpe):

--- a/src/vulnix/nvd.py
+++ b/src/vulnix/nvd.py
@@ -211,11 +211,6 @@ class Vulnerability(Persistent):
     def __init__(self):
         self.affected_products = []
 
-    @property
-    def url(self):
-        return ('https://web.nvd.nist.gov/view/vuln/detail?vulnId={}'.
-                format(self.cve_id))
-
     @staticmethod
     def from_node(node):
         self = Vulnerability()

--- a/src/vulnix/tests/test_nvd.py
+++ b/src/vulnix/tests/test_nvd.py
@@ -1,4 +1,5 @@
 from vulnix.nvd import NVD
+from vulnix.utils import cve_url
 import http.server
 import os
 import pytest
@@ -31,7 +32,7 @@ def test_update_and_parse(tmpdir, http_server):
         cve = mariadb[0]
         assert cve.cve_id == 'CVE-2016-6664'
         assert (
-            cve.url ==
+            cve_url(cve.cve_id) ==
             'https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-6664')
         cpe = list(sorted(cve.affected_products, key=lambda x: x.vendor))[1]
         assert cpe.versions == {'5.7.14', '5.5.51', '5.6.32'}

--- a/src/vulnix/utils.py
+++ b/src/vulnix/utils.py
@@ -1,3 +1,6 @@
+def cve_url(cve_id):
+    return ('https://web.nvd.nist.gov/view/vuln/detail?vulnId={}'.
+            format(cve_id))
 
 
 def batch(iterable, size, callable):


### PR DESCRIPTION
This was caused by adding multiple instances of https://github.com/flyingcircusio/vulnix/blob/1.2.2/src/vulnix/nvd.py#L205 to https://github.com/flyingcircusio/vulnix/blob/1.2.2/src/vulnix/nix.py#L110 .

Every Vulnerability instance will be uniquely hashed and therefore the set will have multiple entries, I replaced the Vulnerability instance with a string which always correspond to the same hash.