### PR TITLE
Match patches case insensitive when guessed from derivation

### DIFF
--- a/src/vulnix/derivation.py
+++ b/src/vulnix/derivation.py
@@ -99,10 +99,10 @@ class Derive(object):
         return call(['nix-store', '--query', '--referrers',
                      self.store_path]).split('\n')
 
-    R_CVE = re.compile(r'CVE-\d{4}-\d+')
+    R_CVE = re.compile(r'CVE-\d{4}-\d+', flags=re.IGNORECASE)
 
     def patched(self):
         """Guess which CVEs are patched from patch names."""
         return set(
-            m.group(0) for m in self.R_CVE.finditer(
+            m.group(0).upper() for m in self.R_CVE.finditer(
                 self.envVars.get('patches', '')))


### PR DESCRIPTION
As commented in https://github.com/NixOS/nixpkgs/pull/32301

We have a whole bunch of CVE patches in nixpkgs that are in lowercase and these currently gives false positives.