### PR TITLE
Fix splitting versions with hyphens

### DIFF
--- a/src/vulnix/derivation.py
+++ b/src/vulnix/derivation.py
@@ -11,7 +11,7 @@ class NoVersionError(RuntimeError):
 
 # see parseDrvName built-in Nix function
 # https://nixos.org/nix/manual/#ssec-builtins
-R_VERSION = re.compile(r'^(\S+)-([0-9]\S*)$')
+R_VERSION = re.compile(r'^(\S+?)-([0-9]\S*)$')
 
 
 def split_name(fullname):

--- a/src/vulnix/tests/test_derivation.py
+++ b/src/vulnix/tests/test_derivation.py
@@ -37,9 +37,9 @@ def test_split_name():
 
 
 def test_split_nameversion():
-    d = Derive(envVars={'name': 'bundler-1.10.5'})
+    d = Derive(envVars={'name': 'bundler-1.10.5-0'})
     assert d.pname == 'bundler'
-    assert d.version == '1.10.5'
+    assert d.version == '1.10.5-0'
 
 
 def test_split_name_noversion():


### PR DESCRIPTION
I noticed that vulnix ignores `imagemagick-7.0.7-23` (that I used to check how vulnix works) because it splits it into `imagemagick-7.0.7` and `23`.