### PR TITLE
Fix wrong format string in Vulnerability.__repr__

### DIFF
--- a/src/vulnix/vulnerability.py
+++ b/src/vulnix/vulnerability.py
@@ -28,7 +28,8 @@ class Vulnerability(Persistent):
         return self.cve_id
 
     def __repr__(self):
-        return '<Vulnerability {}>'.format(self.cve_id, self.cvssv3)
+        return '<Vulnerability {} (cvssv3: {})>'.format(
+            self.cve_id, self.cvssv3)
 
     def __eq__(self, other):
         return self.cve_id == other.cve_id


### PR DESCRIPTION
This (rightfuly) gets flagged as an error in newer versions of flake8,
causing the tests to fail.