### PR TITLE
Ignore entries without cpe23Uri

### DIFF
--- a/src/vulnix/vulnerability.py
+++ b/src/vulnix/vulnerability.py
@@ -107,6 +107,8 @@ class Node:
         for expr in cpe_match:
             if expr.get('vulnerable') is not True:
                 continue
+            if 'cpe23Uri' not in expr:
+                continue
             cpe23Uri = cls.R_UNQUOTE.sub('-', expr['cpe23Uri'])
             (cpe, cpevers, typ, vendor, product, vers, rev, _) = \
                 cpe23Uri.split(':', 7)


### PR DESCRIPTION
Our vulnix GH actions started failing with the following error. This PR, ignores/skips the entries that do not have `cpe23Uri` entry.

```
Traceback (most recent call last):
  File "/nix/store/igxzhckcbrn56grx27dg17q9sjy5b01q-vulnix-1.9.4/bin/.vulnix-wrapped", line 9, in <module>
    sys.exit(main())
  File "/nix/store/02mkfzlja90abihab4fxg2kwz9z8aly7-python3.7-click-7.0/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/nix/store/02mkfzlja90abihab4fxg2kwz9z8aly7-python3.7-click-7.0/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/nix/store/02mkfzlja90abihab4fxg2kwz9z8aly7-python3.7-click-7.0/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/nix/store/02mkfzlja90abihab4fxg2kwz9z8aly7-python3.7-click-7.0/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/nix/store/igxzhckcbrn56grx27dg17q9sjy5b01q-vulnix-1.9.4/lib/python3.7/site-packages/vulnix/main.py", line 137, in main
    nvd.update()
  File "/nix/store/igxzhckcbrn56grx27dg17q9sjy5b01q-vulnix-1.9.4/lib/python3.7/site-packages/vulnix/nvd.py", line 109, in update
    changed.append(arch.download(self.mirror, self.meta))
  File "/nix/store/igxzhckcbrn56grx27dg17q9sjy5b01q-vulnix-1.9.4/lib/python3.7/site-packages/vulnix/nvd.py", line 180, in download
    self.parse(gzip.decompress(r.content))
  File "/nix/store/igxzhckcbrn56grx27dg17q9sjy5b01q-vulnix-1.9.4/lib/python3.7/site-packages/vulnix/nvd.py", line 192, in parse
    vuln = Vulnerability.parse(item)
  File "/nix/store/igxzhckcbrn56grx27dg17q9sjy5b01q-vulnix-1.9.4/lib/python3.7/site-packages/vulnix/vulnerability.py", line 50, in parse
    res.nodes = Node.parse(item['configurations'].get('nodes', []))
  File "/nix/store/igxzhckcbrn56grx27dg17q9sjy5b01q-vulnix-1.9.4/lib/python3.7/site-packages/vulnix/vulnerability.py", line 97, in parse
    res += cls.parse_matches(node.get('cpe_match', []))
  File "/nix/store/igxzhckcbrn56grx27dg17q9sjy5b01q-vulnix-1.9.4/lib/python3.7/site-packages/vulnix/vulnerability.py", line 109, in parse_matches
    cpe23Uri = cls.R_UNQUOTE.sub('-', expr['cpe23Uri'])
KeyError: 'cpe23Uri'
```

Not 100% sure if this is the desired behavior?