### PR TITLE
Use `nix show-derivation` to find derivers when `nix-store -qd` fails

### DIFF
--- a/src/vulnix/nix.py
+++ b/src/vulnix/nix.py
@@ -52,7 +52,12 @@ class Store(object):
         deriver = call(['nix-store', '-qd', path]).strip()
         _log.debug('deriver: %s', deriver)
         if deriver and deriver != 'unknown-deriver':
-            return deriver
+            if p.exists(deriver):
+                return deriver
+            else:
+                raise RuntimeError(
+                    'Deriver `{}` for path `{}` does not exist'.format(
+                        deriver, path))
         raise RuntimeError(
             'Cannot determine deriver. Is this really a path into the '
             'nix store?', path)

--- a/src/vulnix/nix.py
+++ b/src/vulnix/nix.py
@@ -49,15 +49,15 @@ class Store(object):
     def _find_deriver(self, path):
         if path.endswith('.drv'):
             return path
-        deriver = call(['nix-store', '-qd', path]).strip()
-        _log.debug('deriver: %s', deriver)
-        if deriver and deriver != 'unknown-deriver':
-            if p.exists(deriver):
-                return deriver
+        qpi_deriver = call(['nix-store', '-qd', path]).strip()
+        _log.debug('qpi_deriver: %s', qpi_deriver)
+        if qpi_deriver and qpi_deriver != 'unknown-deriver':
+            if p.exists(qpi_deriver):
+                return qpi_deriver
             else:
                 raise RuntimeError(
                     'Deriver `{}` for path `{}` does not exist'.format(
-                        deriver, path))
+                        qpi_deriver, path))
         raise RuntimeError(
             'Cannot determine deriver. Is this really a path into the '
             'nix store?', path)

--- a/src/vulnix/nix.py
+++ b/src/vulnix/nix.py
@@ -47,6 +47,10 @@ class Store(object):
                 self.add_path(line.split()[1])
 
     def _call_nix(self, args):
+        if '--experimental-features' in call(['nix', '--help']):
+            return call(['nix',
+                         '--experimental-features',
+                         'nix-command'] + args)
         return call(['nix'] + args)
 
     def _find_deriver(self, path):

--- a/src/vulnix/nix.py
+++ b/src/vulnix/nix.py
@@ -12,6 +12,7 @@ class Store(object):
     def __init__(self, requisites=True):
         self.requisites = requisites
         self.derivations = set()
+        self.experimental_flag_needed = None
 
     def add_gc_roots(self):
         """Add derivations found for all live GC roots.
@@ -47,7 +48,11 @@ class Store(object):
                 self.add_path(line.split()[1])
 
     def _call_nix(self, args):
-        if '--experimental-features' in call(['nix', '--help']):
+        if self.experimental_flag_needed is None:
+            self.experimental_flag_needed = (
+                '--experimental-features' in call(['nix', '--help']))
+
+        if self.experimental_flag_needed:
             return call(['nix',
                          '--experimental-features',
                          'nix-command'] + args)

--- a/src/vulnix/nix.py
+++ b/src/vulnix/nix.py
@@ -46,6 +46,9 @@ class Store(object):
                               '--profile', profile]).splitlines():
                 self.add_path(line.split()[1])
 
+    def _call_nix(self, args):
+        return call(['nix'] + args)
+
     def _find_deriver(self, path):
         if path.endswith('.drv'):
             return path
@@ -57,7 +60,7 @@ class Store(object):
             return qpi_deriver
         # Deriver from QueryValidDerivers
         qvd_deriver = list(json.loads(
-            call(['nix', 'show-derivation', path])).keys())[0]
+            self._call_nix(['show-derivation', path])).keys())[0]
         _log.debug('qvd_deriver: %s', qvd_deriver)
         if qvd_deriver and p.exists(qvd_deriver):
             return qvd_deriver


### PR DESCRIPTION
Fixes #69