### PR TITLE
Handle multiple version formats gracefully

### DIFF
--- a/src/vulnix/vulnerability.py
+++ b/src/vulnix/vulnerability.py
@@ -121,14 +121,15 @@ class Node:
                 # Exact match: Change self.version to a string with a single
                 # version. Doing this, future attempts to apppend() will fail.
                 e.version = str(vers)
-            if 'versionStartIncluding' in expr:
-                e.version.append('>=' + expr['versionStartIncluding'])
-            if 'versionStartExcluding' in expr:
-                e.version.append('>' + expr['versionStartExcluding'])
-            if 'versionEndIncluding' in expr:
-                e.version.append('<=' + expr['versionEndIncluding'])
-            if 'versionEndExcluding' in expr:
-                e.version.append('<' + expr['versionEndExcluding'])
+            else:
+                if 'versionStartIncluding' in expr:
+                    e.version.append('>=' + expr['versionStartIncluding'])
+                if 'versionStartExcluding' in expr:
+                    e.version.append('>' + expr['versionStartExcluding'])
+                if 'versionEndIncluding' in expr:
+                    e.version.append('<=' + expr['versionEndIncluding'])
+                if 'versionEndExcluding' in expr:
+                    e.version.append('<' + expr['versionEndExcluding'])
             if e.version:
                 # no point adding an expr without any version match
                 nodes.append(e)


### PR DESCRIPTION
The NVD occasionally has inconsistently structured entries, which Vulnix generally tries to keep going through. #68 recently fixed one of the bugs which can arise from this, however, sometimes entries have multiple version formats which currently causes crashes.

One version format results in `e.version` being set to a string, whereas the other relies on it being a list. Calling `append` on a string causes the crash, which can be avoided by simply ensuring only one or the other format for version data is extracted. It isn't too important which is extracted, since this are generally temporary inconsistencies which are fixed on the NVD, so this needs to just be good enough and not crash.