### PR TITLE
Expose CVE descriptions

### DIFF
--- a/src/vulnix/main.py
+++ b/src/vulnix/main.py
@@ -104,6 +104,8 @@ def run(nvd, store):
 @click.option('-j', '--json/--no-json', help='JSON vs. human readable output.')
 @click.option('-s', '--show-whitelisted', is_flag=True,
               help='Shows whitelisted items as well')
+@click.option('-D', '--show-description', is_flag=True,
+              help='Show descriptions of vulnerabilities')
 @click.option('-v', '--verbose', count=True,
               help='Increase output verbosity (up to 2 times).')
 @click.option('-V', '--version', is_flag=True,
@@ -114,7 +116,7 @@ def run(nvd, store):
               help='(obsolete; kept for compatibility reasons)')
 def main(verbose, gc_roots, system, from_file, profile, path, mirror,
          cache_dir, requisites, whitelist, write_whitelist, version, json,
-         show_whitelisted, default_whitelist, notfixed):
+         show_whitelisted, show_description, default_whitelist, notfixed):
     if version:
         print('vulnix ' + pkg_resources.get_distribution('vulnix').version)
         sys.exit(0)
@@ -152,7 +154,12 @@ def main(verbose, gc_roots, system, from_file, profile, path, mirror,
             with Timer('Scan vulnerabilities'):
                 filtered_items = whitelist.filter(run(nvd, store))
 
-            rc = output(filtered_items, json, show_whitelisted)
+            rc = output(
+                filtered_items,
+                json,
+                show_whitelisted,
+                show_description,
+            )
             if write_whitelist:
                 for i in filtered_items:
                     whitelist.add_from(i)

--- a/src/vulnix/output.py
+++ b/src/vulnix/output.py
@@ -4,10 +4,13 @@ import functools
 import json
 
 
-def fmt_vuln(v):
+def fmt_vuln(v, show_description=False):
     out = 'https://nvd.nist.gov/vuln/detail/{:17}'.format(v.cve_id)
-    if v.cvssv3:
-        out += ' {}'.format(v.cvssv3)
+    out += ' {:<8} '.format(v.cvssv3 or "")
+    if show_description:
+        # Show the description in a different color as they can run over the line length,
+        # and this makes distinguishing them from the next entry easy
+        out += click.style(v.description or "", fg="cyan")
     return out.rstrip()
 
 
@@ -53,7 +56,7 @@ class Filtered:
             self.masked |= self.report
             self.report = set()
 
-    def print(self, show_masked=False):
+    def print(self, show_masked=False, show_description=False):
         if not self.report and not show_masked:
             return
         d = self.derivation
@@ -64,12 +67,22 @@ class Filtered:
         if d.store_path:
             click.secho(d.store_path, fg='magenta', dim=wl)
 
-        click.secho('{:50} {}'.format('CVE', 'CVSSv3'), dim=wl)
+        click.secho(
+            '{:50} {:<8} {}'.format(
+                'CVE',
+                'CVSSv3',
+                'Description' if show_description else ''
+            ).rstrip(),
+            dim=wl
+        )
         for v in sorted(self.report, key=vuln_sort_key):
-            click.echo(fmt_vuln(v))
+            click.echo(fmt_vuln(v, show_description))
         if show_masked:
             for v in sorted(self.masked, key=vuln_sort_key):
-                click.secho("{}  [whitelisted]".format(fmt_vuln(v)), dim=True)
+                click.secho("{}  [whitelisted]".format(fmt_vuln(
+                    v,
+                    show_description
+                )), dim=True)
 
         issues = functools.reduce(
             set.union, (r.issue_url for r in self.rules), set())
@@ -84,7 +97,7 @@ class Filtered:
                     click.secho('* ' + comment, fg='blue', dim=wl)
 
 
-def output_text(vulns, show_whitelisted=False):
+def output_text(vulns, show_whitelisted=False, show_description=False):
     report = [v for v in vulns if v.report]
     wl = [v for v in vulns if not v.report]
 
@@ -103,10 +116,10 @@ def output_text(vulns, show_whitelisted=False):
             len(wl)), fg='blue')
 
     for i in sorted(report, key=attrgetter('derivation')):
-        i.print(show_whitelisted)
+        i.print(show_whitelisted, show_description)
     if show_whitelisted:
         for i in sorted(wl, key=attrgetter('derivation')):
-            i.print(show_whitelisted)
+            i.print(show_whitelisted, show_description)
     if wl and not show_whitelisted:
         click.secho('\nuse --show-whitelisted to see derivations with only '
                     'whitelisted CVEs', fg='blue')
@@ -125,17 +138,25 @@ def output_json(items, show_whitelisted=False):
             'derivation': d.store_path,
             'affected_by': sorted(v.cve_id for v in i.report),
             'whitelisted': sorted(v.cve_id for v in i.masked),
-            'cvssv3_basescore':
-                {v.cve_id: v.cvssv3 for v in (i.report | i.masked) if v.cvssv3}
+            'cvssv3_basescore': {
+                v.cve_id: v.cvssv3
+                for v in (i.report | i.masked)
+                if v.cvssv3
+            },
+            'description': {
+                v.cve_id: v.description
+                for v in (i.report | i.masked)
+                if v.description
+            },
         })
     print(json.dumps(out, indent=1))
 
 
-def output(items, json=False, show_whitelisted=False):
+def output(items, json=False, show_whitelisted=False, show_description=False):
     if json:
         output_json(items, show_whitelisted)
     else:
-        output_text(items, show_whitelisted)
+        output_text(items, show_whitelisted, show_description)
     if any(i.report for i in items):
         return 2
     if show_whitelisted and any(i.masked for i in items):

--- a/src/vulnix/tests/output_test.py
+++ b/src/vulnix/tests/output_test.py
@@ -121,7 +121,8 @@ def test_output_json(wl_items, capsys):
          'pname': 'foo',
          'version': '1',
          'whitelisted': ['CVE-2018-0004'],
-         'cvssv3_basescore': {}},
+         'cvssv3_basescore': {},
+         'description': {}},
         {'affected_by': ['CVE-2018-0001', 'CVE-2018-0002', 'CVE-2018-0003'],
          'derivation': '/nix/store/zsawgflc1fq77ijjzb1369zi6kxnc36j-test-0.2',
          'name': 'test-0.2',
@@ -130,7 +131,8 @@ def test_output_json(wl_items, capsys):
          'whitelisted': [],
          'cvssv3_basescore': {
              'CVE-2018-0003': 9.8,
-         }},
+         },
+         'description': {}},
     ]
 
 

--- a/src/vulnix/vulnerability.py
+++ b/src/vulnix/vulnerability.py
@@ -17,12 +17,19 @@ class Vulnerability(Persistent):
     nodes = None
     cvssv3 = 0.0
     cvssv2 = 0.0
+    description = None
 
-    def __init__(self, cve_id, nodes=None, cvssv3=0.0, cvssv2=0.0):
+    def __init__(self,
+                 cve_id,
+                 nodes=None,
+                 cvssv3=0.0,
+                 cvssv2=0.0,
+                 description=''):
         self.cve_id = cve_id
         self.nodes = nodes or []
         self.cvssv3 = float(cvssv3)
         self.cvssv2 = float(cvssv2)
+        self.description = description
 
     def __str__(self):
         return self.cve_id
@@ -55,6 +62,13 @@ class Vulnerability(Persistent):
         if haskeys(item, 'impact', 'baseMetricV2', 'cvssV2', 'baseScore'):
             res.cvssv2 = float(
                 item['impact']['baseMetricV2']['cvssV2']['baseScore'])
+        if haskeys(item, 'cve', 'description', 'description_data'):
+            res.description = next((
+                description['value']
+                for description
+                in item['cve']['description']['description_data']
+                if description.get('lang', 'en') == 'en'
+            ), '')
         return res
 
     def match(self, pname, pvers):


### PR DESCRIPTION
The NVD provides descriptions for CVEs, which are collected by Vulnix when retrieving vulnerability data. However, Vulnix ignores this information, and doesn't expose it to the user. Whilst users can go online to read descriptions of each vulnerability individually, this can become difficult if many Nix packages are installed, and so there are many different CVEs. This information can be crucial for determining the real impact of a CVE given how a tool may be used, and thus quickly isolating concerning CVEs for a system. For scripts using Vulnix output with `-j`, this saves having to download the same information again that Vulnix has already downloaded, and removing the overhead required to handle the NVD from these scripts.

The descriptions can always be given in any JSON output as scripts handling this can easily ignore it if is not relevant, but is behind a flag for human-readable output as descriptions can make the output much longer, so may hinder current workflows. The descriptions are coloured cyan to stand out as well, so they can easily be distinguished from the next entry, as long descriptions can easily hang over the next line.