### PR TITLE
setup.py: allow pyyaml 6.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     install_requires=[
         'click>=6.7',
         'colorama>=0.3',
-        'pyyaml>=5,<6',
+        'pyyaml>=5,<7',
         'requests>=2.18',
         'toml>=0.9',
         'ZODB>=5.4',


### PR DESCRIPTION
nixpkgs recently bumped its pyyaml version to 6.x, breaking vulnix build. Tests still seem to pass with the new pyyaml version, as well as `vulnix --system`.