### PR TITLE
Allow proper globbing in whitelists, add option to list all unused whitelist rules

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,9 +4,7 @@
 }:
 
 # uses build in upstream nixpkgs
-(pkgs.callPackage "${nixpkgs}/pkgs/tools/security/vulnix" {
-  python3Packages = pkgs.python37Packages;
-}).overrideAttrs (
+(pkgs.callPackage "${nixpkgs}/pkgs/tools/security/vulnix" {}).overrideAttrs (
   old: rec {
     src = lib.cleanSource ./.;
     version = lib.removeSuffix "\n" (builtins.readFile ./VERSION);

--- a/src/vulnix/main.py
+++ b/src/vulnix/main.py
@@ -173,3 +173,7 @@ def main(verbose, gc_roots, system, from_file, profile, path, mirror,
     except RuntimeError as e:
         _log.exception(e)
         sys.exit(2)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/vulnix/main.py
+++ b/src/vulnix/main.py
@@ -114,9 +114,12 @@ def run(nvd, store):
               help='(obsolete; kept for compatibility reasons)')
 @click.option('-F', '--notfixed', is_flag=True,
               help='(obsolete; kept for compatibility reasons)')
+@click.option('-u', '--unused', is_flag=True,
+              help='Shows unused whitelist entries at the bottom')
 def main(verbose, gc_roots, system, from_file, profile, path, mirror,
          cache_dir, requisites, whitelist, write_whitelist, version, json,
-         show_whitelisted, show_description, default_whitelist, notfixed):
+         show_whitelisted, show_description, default_whitelist, notfixed,
+         unused):
     if version:
         print('vulnix ' + pkg_resources.get_distribution('vulnix').version)
         sys.exit(0)
@@ -156,6 +159,8 @@ def main(verbose, gc_roots, system, from_file, profile, path, mirror,
 
             rc = output(
                 filtered_items,
+                whitelist,
+                unused,
                 json,
                 show_whitelisted,
                 show_description,
@@ -166,6 +171,7 @@ def main(verbose, gc_roots, system, from_file, profile, path, mirror,
                 write_whitelist.close()
                 with open(write_whitelist.name, 'w') as f:
                     f.write(str(whitelist))
+
         sys.exit(rc)
 
     # This needs to happen outside the NVD context: otherwise ZODB will abort

--- a/src/vulnix/tests/fixtures/whitelist.yaml
+++ b/src/vulnix/tests/fixtures/whitelist.yaml
@@ -10,15 +10,12 @@
     name: unzip
     status: inprogress
 -
-    name: libxslt
-    version: '2.0'
+    name: libxslt-2.0
     until: 2018-03-01
 -
-    name: audiofile
-    version: '0.3.2'
+    name: audiofile-0.3.2
 -
-    name: audiofile
-    version: '0.3.6'
+    name: audiofile-0.3.6
     cve:
         - CVE-2017-6827
         - CVE-2017-6828

--- a/src/vulnix/tests/output_test.py
+++ b/src/vulnix/tests/output_test.py
@@ -53,19 +53,19 @@ def test_init(deriv):
 
 def test_add_unspecific_rule(deriv):
     f = Filtered(*deriv)
-    f.add(WhitelistRule(pname='test', version='1.2'))
+    f.add(WhitelistRule(name='test', version='1.2'))
     assert not f.report
 
 
 def test_add_rule_with_cves(filt):
-    filt.add(WhitelistRule(pname='test', version='1.2', cve={'CVE-2018-0001'}))
+    filt.add(WhitelistRule(name='test', version='1.2', cve={'CVE-2018-0001'}))
     assert filt.report == {V('CVE-2018-0002'), V('CVE-2018-0003')}
     assert filt.masked == {V('CVE-2018-0001')}
 
 
 def test_add_temporary_whitelist(filt):
     assert not filt.until
-    filt.add(WhitelistRule(pname='test', version='1.2', until='2018-03-05'))
+    filt.add(WhitelistRule(name='test', version='1.2', until='2018-03-05'))
     assert filt.until == datetime.date(2018, 3, 5)
 
 
@@ -75,7 +75,7 @@ def wl_items(items):
     items[1].add(WhitelistRule(
         cve={'CVE-2018-0004'}, issue_url='https://tracker/4'))
     # makes deriv2 disappear completely
-    items[2].add(WhitelistRule(pname='bar', comment='irrelevant'))
+    items[2].add(WhitelistRule(name='bar', comment='irrelevant'))
     return items
 
 
@@ -144,7 +144,7 @@ def test_exitcode(items, capsys):
     assert output(items) == 2
     # everything masked
     for i in items:
-        i.add(WhitelistRule(pname=i.derivation.pname))
+        i.add(WhitelistRule(name=i.derivation.pname))
     assert output(items) == 0
     assert output(items, show_whitelisted=True) == 1
     capsys.readouterr()  # swallow stdout/stderr: it doesn't matter here

--- a/src/vulnix/tests/whitelist_test.py
+++ b/src/vulnix/tests/whitelist_test.py
@@ -263,24 +263,6 @@ def test_toml_malformed_url():
         Whitelist.load(io.StringIO('["pkg"]\nissue_url = "foobar"'))
 
 
-def test_section_header_unexpected_space():
-    with pytest.raises(RuntimeError):
-        Whitelist.load(io.StringIO("""
-["ok-section-1.0"]
-
-[ "broken-section-1.1" ]
-comment = "whitespace confuses TOML parser"
-"""))
-
-
-def test_section_header_unexpected_space_2():
-    with pytest.raises(RuntimeError):
-        Whitelist.load(io.StringIO("""
-["broken-section 1.2"]
-comment = "incorrect whitespace between package and version"
-"""))
-
-
 def test_section_header_alphanumeric():
     Whitelist.load(io.StringIO("""
 [systemd-236]

--- a/src/vulnix/tests/whitelist_test.py
+++ b/src/vulnix/tests/whitelist_test.py
@@ -50,20 +50,20 @@ def test_parse_until():
 
 
 def test_match_pname_version():
-    rule = WhitelistRule(pname='libxslt', version='2.0')
+    rule = WhitelistRule(name='libxslt-2.0')
     assert rule.covers(Derive(name='libxslt-2.0'))
     assert not rule.covers(Derive(name='libxslt-2.1'))
 
 
 def test_match_pname_only():
-    rule = WhitelistRule(pname='libxslt', version='*')
+    rule = WhitelistRule(name='libxslt-*')
     assert rule.covers(Derive(name='libxslt-2.0'))
     assert rule.covers(Derive(name='libxslt-2.1'))
     assert not rule.covers(Derive(name='libxml2-2.0'))
 
 
 def test_match_pname_version_cve():
-    rule = WhitelistRule(pname='cpio', version='2.12', cve=['CVE-2015-1197'])
+    rule = WhitelistRule(name='cpio-2.12', cve=['CVE-2015-1197'])
     assert rule.covers(Derive(name='cpio-2.12'), {V('CVE-2015-1197')})
     assert not rule.covers(Derive(name='cpio-2.12'), {V('CVE-2015-1198')})
 
@@ -80,8 +80,21 @@ def test_match_partial():
             Derive(name='cpio-2.12'), {V('CVE-2015-1197'), V('CVE-2015-1198')})
 
 
+def test_match_wildcard_version():
+    rule = WhitelistRule(name='libxslt-2.*')
+    assert rule.covers(Derive(name='libxslt-2.5'))
+    assert not rule.covers(Derive(name='libxslt-1.5'))
+
+
+def test_match_pname_wildcard():
+    rule = WhitelistRule(name='lib*-2.0')
+    assert rule.covers(Derive(name='libfoo-2.0'))
+    assert not rule.covers(Derive(name='libbar-1.0'))
+    assert not rule.covers(Derive(name='glibc-2.0'))
+
+
 def test_until(whitelist_toml):
-    rule = WhitelistRule(pname='libxslt', until='2018-04-12')
+    rule = WhitelistRule(name='libxslt-*', until='2018-04-12')
     d = Derive(name='libxslt-2.0')
     with freezegun.freeze_time('2018-04-11'):
         assert rule.covers(d)

--- a/src/vulnix/whitelist.py
+++ b/src/vulnix/whitelist.py
@@ -167,7 +167,6 @@ class Whitelist:
 
     TOML_SECTION_START = re.compile(r'^\[.*\]', re.MULTILINE)
     YAML_SECTION_START = re.compile(r'^-', re.MULTILINE)
-    SECTION_FORMAT = re.compile(r'^[a-zA-Z0-9_.*-]+$')
 
     @classmethod
     def load(cls, fobj):
@@ -203,8 +202,6 @@ class Whitelist:
 
         self = cls()
         for rule in gen:
-            if not self.SECTION_FORMAT.match(rule.name):
-                raise RuntimeError('invalid package selector', rule.name)
             self.insert(rule)
         return self
 

--- a/src/vulnix/whitelist.py
+++ b/src/vulnix/whitelist.py
@@ -68,6 +68,7 @@ class WhitelistRule:
     """
 
     name = None
+    used_counter = 0
 
     def __init__(self, **kw):
         self.name = kw.pop('name', None) or '*'
@@ -139,6 +140,7 @@ class WhitelistRule:
             return False
         if self.until and self.until <= datetime.date.today():
             return False
+        self.used_counter += 1
         return True
 
 
@@ -247,3 +249,6 @@ class Whitelist:
         self.update(WhitelistRule(
             name=n,
             cve={i.cve_id for i in filtered_item.report}))
+
+    def unused_rules(self):
+        return (x for x in self.entries.values() if x.used_counter == 0)


### PR DESCRIPTION
__Note:__ the changes aren't as trivial as I initially hoped, so I'd suggest to review this on a per-commit basis and also read the commit messages for further context!

This implements two things I wanted to have in vulnix for quite a while:

* being able to actually glob whitelist rules rather than just supporting a `*` for `pname`/`version`, i.e. `go-*-*-linux-bootstrap` is now possible.
* Add `-u` as option to list all unused whitelist rules.